### PR TITLE
Try to fix metadata crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /config
 options.txt
 /saves
+/libs
 usernamecache.json
 
 # Eclipse

--- a/src/main/java/erogenousbeef/bigreactors/common/multiblock/block/BlockMultiblockGlass.java
+++ b/src/main/java/erogenousbeef/bigreactors/common/multiblock/block/BlockMultiblockGlass.java
@@ -7,6 +7,7 @@ import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -58,8 +59,14 @@ public class BlockMultiblockGlass extends BlockContainer {
 			throw new IllegalArgumentException("Unrecognized metadata");
 		}
 	}
-	
-	@Override
+
+    @Override
+    public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack)
+    {
+        world.setBlockMetadataWithNotify(x, y, z, stack.getItemDamage(), 2);
+    }
+
+    @Override
 	@SideOnly(Side.CLIENT)
 	public void registerBlockIcons(IIconRegister par1IconRegister)
 	{


### PR DESCRIPTION
This workaround might fix https://github.com/erogenousbeef/BigReactors/issues/566 but it needs to be tested by someone who is experiencing this crash. The code will still throw an exception if the metadata is higher than 1. In that case the multiblock code can't detect the glass block because it is missing the tile entity.